### PR TITLE
Reorganize tests

### DIFF
--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -7,13 +7,13 @@ const create = async (textBody: string): Promise<ITodo> => {
   return await new Todo({ textBody, isComplete: false }).save();
 };
 
+const readAll = async (): Promise<ITodo[]> => {
+  return await Todo.find();
+};
+
 const readById = async (id: string): Promise<ITodo | null> => {
   validator.validateId(id);
   return await Todo.findById(id);
-};
-
-const readAll = async (): Promise<ITodo[]> => {
-  return await Todo.find();
 };
 
 const updateCompleteById = async (id: string): Promise<ITodo | null> => {

--- a/src/tests/app.test.ts
+++ b/src/tests/app.test.ts
@@ -3,7 +3,7 @@ import * as db from "./testDb";
 import * as request from "supertest";
 import { ITodo } from "../types";
 
-describe("Todo List App", () => {
+describe("Todo List REST API", () => {
   beforeAll(async () => {
     await db.connect();
   });
@@ -27,258 +27,289 @@ describe("Todo List App", () => {
   const longTextBody =
     "11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111";
 
-  it("should create a todo", async () => {
-    const res = await request(app).post("/todos").send(testData);
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 201);
-    expect(res).toHaveProperty("body");
+  describe("POST /todos/{id}", () => {
+    describe("success", () => {
+      it("should create a todo", async () => {
+        const res = await request(app).post("/todos").send(testData);
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 201);
+        expect(res).toHaveProperty("body");
 
-    expect(res.body).toHaveProperty("message");
-    expect(res.body).toHaveProperty("todo");
-    expect(res.body).toHaveProperty("todos");
-    const { todo, todos } = res.body;
+        expect(res.body).toHaveProperty("message");
+        expect(res.body).toHaveProperty("todo");
+        expect(res.body).toHaveProperty("todos");
+        const { todo, todos } = res.body;
 
-    expect(todo).toHaveProperty("_id");
-    expect(todo).toHaveProperty("textBody", testData.textBody);
-    expect(todo).toHaveProperty("isComplete", false);
-    expect(todo).toHaveProperty("createdAt");
-    expect(todo).toHaveProperty("updatedAt");
-    expect(todos).toHaveLength(1);
-  });
-
-  it("should fetch a todo", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const expected = postRes.body.todo;
-
-    const res = await request(app).get(`/todos/${expected._id}`);
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 200);
-    expect(res).not.toHaveProperty("message");
-    expect(res).toHaveProperty("body");
-    expect(res.body).toHaveProperty("todo");
-    const { todo: actual } = res.body;
-
-    expect(actual).toHaveProperty("_id", expected._id);
-    expect(actual).toHaveProperty("textBody", expected.textBody);
-    expect(actual).toHaveProperty("isComplete", expected.isComplete);
-    expect(actual).toHaveProperty("createdAt", expected.createdAt);
-    expect(actual).toHaveProperty("updatedAt", expected.updatedAt);
-  });
-
-  it("should fetch all todos", async () => {
-    const testDataA = { textBody: "testA" };
-    const testDataB = { textBody: "testB" };
-    const testDataC = { textBody: "testC" };
-    const postResA = await request(app).post("/todos").send(testDataA);
-    const postResB = await request(app).post("/todos").send(testDataB);
-    const postResC = await request(app).post("/todos").send(testDataC);
-    const expectedA: ITodo = postResA.body.todo;
-    const expectedB: ITodo = postResB.body.todo;
-    const expectedC: ITodo = postResC.body.todo;
-
-    const res = await request(app).get("/todos");
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 200);
-    expect(res).toHaveProperty("body");
-    expect(res.body).not.toHaveProperty("message");
-    expect(res.body).toHaveProperty("todos");
-    const { todos: actual } = res.body;
-
-    expect(actual).toHaveLength(3);
-    expect(actual[0].toJSON).toEqual(expectedA.toJSON);
-    expect(actual[1].toJSON).toEqual(expectedB.toJSON);
-    expect(actual[2].toJSON).toEqual(expectedC.toJSON);
-  });
-
-  it("should fetch all todos as an empty array if no todos are found", async () => {
-    const res = await request(app).get("/todos");
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 200);
-    expect(res).toHaveProperty("body");
-    expect(res.body).toHaveProperty("todos");
-    const { todos } = res.body;
-    expect(todos).toHaveLength(0);
-    expect(todos).toStrictEqual([]);
-  });
-
-  it("should update the text of a todo", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-
-    const res = await request(app)
-      .put(`/todos/${originalTodo._id}`)
-      .send({ textBody: updateData.textBody });
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 200);
-    expect(res).toHaveProperty("body");
-    expect(res.body).toHaveProperty("message");
-    expect(res.body).toHaveProperty("todo");
-    expect(res.body).toHaveProperty("todos");
-    const { todo: updatedTodo, todos } = res.body;
-
-    expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
-    expect(updatedTodo).toHaveProperty("textBody", updateData.textBody);
-    expect(updatedTodo).toHaveProperty("isComplete", originalTodo.isComplete);
-    expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
-    expect(updatedTodo).toHaveProperty("updatedAt");
-    expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
-    expect(todos).toHaveLength(1);
-  });
-
-  it("should update the completion status of a todo if no text is provided", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-
-    const res = await request(app).put(`/todos/${originalTodo._id}`);
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 200);
-    expect(res).toHaveProperty("body");
-    expect(res.body).toHaveProperty("message");
-    expect(res.body).toHaveProperty("todo");
-    expect(res.body).toHaveProperty("todos");
-    const { todo: updatedTodo, todos } = res.body;
-
-    expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
-    expect(updatedTodo).toHaveProperty("textBody", originalTodo.textBody);
-    expect(updatedTodo).toHaveProperty("isComplete", !originalTodo.isComplete);
-    expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
-    expect(updatedTodo).toHaveProperty("updatedAt");
-    expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
-    expect(todos).toHaveLength(1);
-  });
-
-  it("should delete a todo", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-
-    const res = await request(app).delete(`/todos/${originalTodo._id}`);
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 200);
-    expect(res).toHaveProperty("body");
-    expect(res.body).toHaveProperty("message");
-    expect(res.body).toHaveProperty("todo");
-    expect(res.body).toHaveProperty("todos");
-    const { todo, todos } = res.body;
-
-    expect(todo).toHaveProperty("_id", originalTodo._id);
-    expect(todo).toHaveProperty("textBody", originalTodo.textBody);
-    expect(todo).toHaveProperty("isComplete", originalTodo.isComplete);
-    expect(todo).toHaveProperty("createdAt", originalTodo.createdAt);
-    expect(todo).toHaveProperty("updatedAt", originalTodo.updatedAt);
-    expect(todos).toHaveLength(0);
-  });
-
-  it("should 404 GET requests if no todo is found", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-    await request(app).delete(`/todos/${originalTodo._id}`);
-
-    const res = await request(app).get(`/todos/${originalTodo._id}`);
-    expectStatusCode(res, 404);
-  });
-
-  it("should 404 PUT requests to update the text of a todo if no todo is found", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-    await request(app).delete(`/todos/${originalTodo._id}`);
-
-    const res = await request(app)
-      .put(`/todos/${originalTodo._id}`)
-      .send(updateData);
-    expectStatusCode(res, 404);
-  });
-
-  it("should 404 PUT requests to update the completion status of a todo if no todo is found", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-    await request(app).delete(`/todos/${originalTodo._id}`);
-
-    const res = await request(app).put(`/todos/${originalTodo._id}`);
-    expectStatusCode(res, 404);
-  });
-
-  it("should 404 DELETE requests if no todo is found", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-    await request(app).delete(`/todos/${originalTodo._id}`);
-
-    const res = await request(app).delete(`/todos/${originalTodo._id}`);
-    expectStatusCode(res, 404);
-  });
-
-  it("should 400 POST requests with no textBody", async () => {
-    const res = await request(app).post("/todos");
-    expectStatusCode(res, 400);
-  });
-
-  it("should 400 POST requests with an empty string", async () => {
-    const res = await request(app).post("/todos").send({ textBody: "" });
-    expectStatusCode(res, 400);
-  });
-
-  it("should 400 POST requests with a textBody over 255 characters long", async () => {
-    const res = await request(app).post("/todos").send({
-      textBody: longTextBody,
+        expect(todo).toHaveProperty("_id");
+        expect(todo).toHaveProperty("textBody", testData.textBody);
+        expect(todo).toHaveProperty("isComplete", false);
+        expect(todo).toHaveProperty("createdAt");
+        expect(todo).toHaveProperty("updatedAt");
+        expect(todos).toHaveLength(1);
+      });
     });
-    expectStatusCode(res, 400);
-  });
+    describe("failure", () => {
+      it("should 400 requests with no textBody", async () => {
+        const res = await request(app).post("/todos");
+        expectStatusCode(res, 400);
+      });
 
-  it("should 400 GET requests with an invalid id format", async () => {
-    const res = await request(app).get("/todos/1");
-    expectStatusCode(res, 400);
-  });
+      it("should 400 requests with an empty string", async () => {
+        const res = await request(app).post("/todos").send({ textBody: "" });
+        expectStatusCode(res, 400);
+      });
 
-  it("should 404 PUT requests with no id", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-
-    const res = await request(app).put("/todos");
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 404);
-  });
-
-  it("should 400 PUT requests to update the text of a todo with an invalid id format", async () => {
-    const res = await request(app).put("/todos/1").send(updateData);
-    expectStatusCode(res, 400);
-  });
-
-  it("should 400 PUT requests to update the completion status of a todo with an invalid id format", async () => {
-    const res = await request(app).put("/todos/1");
-    expectStatusCode(res, 400);
-  });
-
-  it("should 400 PUT requests to update the text of a todo with an empty string", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-
-    const res = await request(app)
-      .put(`/todos/${originalTodo._id}`)
-      .send({ textBody: "" });
-    expectStatusCode(res, 400);
-  });
-
-  it("should 400 PUT requests with a textBody over 255 characters long", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
-
-    const res = await request(app).put(`/todos/${originalTodo._id}`).send({
-      textBody: longTextBody,
+      it("should 400 requests with a textBody over 255 characters long", async () => {
+        const res = await request(app).post("/todos").send({
+          textBody: longTextBody,
+        });
+        expectStatusCode(res, 400);
+      });
     });
-    expectStatusCode(res, 400);
   });
 
-  it("should 404 DELETE requests with no id", async () => {
-    const postRes = await request(app).post("/todos").send(testData);
-    const originalTodo = postRes.body.todo;
+  describe("GET /todos", () => {
+    describe("success", () => {
+      it("should fetch all todos", async () => {
+        const testDataA = { textBody: "testA" };
+        const testDataB = { textBody: "testB" };
+        const testDataC = { textBody: "testC" };
+        const postResA = await request(app).post("/todos").send(testDataA);
+        const postResB = await request(app).post("/todos").send(testDataB);
+        const postResC = await request(app).post("/todos").send(testDataC);
+        const expectedA: ITodo = postResA.body.todo;
+        const expectedB: ITodo = postResB.body.todo;
+        const expectedC: ITodo = postResC.body.todo;
 
-    const res = await request(app).delete("/todos");
-    expect(Object.is(res, null)).toBe(false);
-    expect(res).toHaveProperty("statusCode", 404);
+        const res = await request(app).get("/todos");
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 200);
+        expect(res).toHaveProperty("body");
+        expect(res.body).not.toHaveProperty("message");
+        expect(res.body).toHaveProperty("todos");
+        const { todos: actual } = res.body;
+
+        expect(actual).toHaveLength(3);
+        expect(actual[0].toJSON).toEqual(expectedA.toJSON);
+        expect(actual[1].toJSON).toEqual(expectedB.toJSON);
+        expect(actual[2].toJSON).toEqual(expectedC.toJSON);
+      });
+
+      it("should fetch an empty array if no todos are found", async () => {
+        const res = await request(app).get("/todos");
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 200);
+        expect(res).toHaveProperty("body");
+        expect(res.body).toHaveProperty("todos");
+        const { todos } = res.body;
+        expect(todos).toHaveLength(0);
+        expect(todos).toStrictEqual([]);
+      });
+    });
+    describe("failure", () => {});
   });
 
-  it("should 400 DELETE requests with an invalid id format", async () => {
-    const res = await request(app).delete("/todos/1");
-    expectStatusCode(res, 400);
+  describe("GET /todos/{id}", () => {
+    describe("success", () => {
+      it("should fetch a todo", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const expected = postRes.body.todo;
+
+        const res = await request(app).get(`/todos/${expected._id}`);
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 200);
+        expect(res).not.toHaveProperty("message");
+        expect(res).toHaveProperty("body");
+        expect(res.body).toHaveProperty("todo");
+        const { todo: actual } = res.body;
+
+        expect(actual).toHaveProperty("_id", expected._id);
+        expect(actual).toHaveProperty("textBody", expected.textBody);
+        expect(actual).toHaveProperty("isComplete", expected.isComplete);
+        expect(actual).toHaveProperty("createdAt", expected.createdAt);
+        expect(actual).toHaveProperty("updatedAt", expected.updatedAt);
+      });
+
+      it("should 404 when no todo is found", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+        await request(app).delete(`/todos/${originalTodo._id}`);
+
+        const res = await request(app).get(`/todos/${originalTodo._id}`);
+        expectStatusCode(res, 404);
+      });
+    });
+    describe("failure", () => {
+      it("should 400 requests with an invalid id format", async () => {
+        const res = await request(app).get("/todos/1");
+        expectStatusCode(res, 400);
+      });
+    });
+  });
+
+  describe("PUT /todos/{id}", () => {
+    describe("success", () => {
+      it("should update the text of a todo", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app)
+          .put(`/todos/${originalTodo._id}`)
+          .send({ textBody: updateData.textBody });
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 200);
+        expect(res).toHaveProperty("body");
+        expect(res.body).toHaveProperty("message");
+        expect(res.body).toHaveProperty("todo");
+        expect(res.body).toHaveProperty("todos");
+        const { todo: updatedTodo, todos } = res.body;
+
+        expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
+        expect(updatedTodo).toHaveProperty("textBody", updateData.textBody);
+        expect(updatedTodo).toHaveProperty(
+          "isComplete",
+          originalTodo.isComplete
+        );
+        expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
+        expect(updatedTodo).toHaveProperty("updatedAt");
+        expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
+        expect(todos).toHaveLength(1);
+      });
+
+      it("should update the completion status of a todo if no text is provided", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app).put(`/todos/${originalTodo._id}`);
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 200);
+        expect(res).toHaveProperty("body");
+        expect(res.body).toHaveProperty("message");
+        expect(res.body).toHaveProperty("todo");
+        expect(res.body).toHaveProperty("todos");
+        const { todo: updatedTodo, todos } = res.body;
+
+        expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
+        expect(updatedTodo).toHaveProperty("textBody", originalTodo.textBody);
+        expect(updatedTodo).toHaveProperty(
+          "isComplete",
+          !originalTodo.isComplete
+        );
+        expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
+        expect(updatedTodo).toHaveProperty("updatedAt");
+        expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
+        expect(todos).toHaveLength(1);
+      });
+    });
+    describe("failure", () => {
+      it("should 404 requests to update the text of a todo if no todo is found", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+        await request(app).delete(`/todos/${originalTodo._id}`);
+
+        const res = await request(app)
+          .put(`/todos/${originalTodo._id}`)
+          .send(updateData);
+        expectStatusCode(res, 404);
+      });
+
+      it("should 404 requests to update the completion status of a todo if no todo is found", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+        await request(app).delete(`/todos/${originalTodo._id}`);
+
+        const res = await request(app).put(`/todos/${originalTodo._id}`);
+        expectStatusCode(res, 404);
+      });
+
+      it("should 404 requests with no id", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app).put("/todos");
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 404);
+      });
+
+      it("should 400 requests to update the text of a todo with an invalid id format", async () => {
+        const res = await request(app).put("/todos/1").send(updateData);
+        expectStatusCode(res, 400);
+      });
+
+      it("should 400 requests to update the completion status of a todo with an invalid id format", async () => {
+        const res = await request(app).put("/todos/1");
+        expectStatusCode(res, 400);
+      });
+
+      it("should 400 requests to update the text of a todo with an empty string", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app)
+          .put(`/todos/${originalTodo._id}`)
+          .send({ textBody: "" });
+        expectStatusCode(res, 400);
+      });
+
+      it("should 400 requests with a textBody over 255 characters long", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app).put(`/todos/${originalTodo._id}`).send({
+          textBody: longTextBody,
+        });
+        expectStatusCode(res, 400);
+      });
+    });
+  });
+
+  describe("DELETE /todos/{id}", () => {
+    describe("success", () => {
+      it("should delete a todo", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app).delete(`/todos/${originalTodo._id}`);
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 200);
+        expect(res).toHaveProperty("body");
+        expect(res.body).toHaveProperty("message");
+        expect(res.body).toHaveProperty("todo");
+        expect(res.body).toHaveProperty("todos");
+        const { todo, todos } = res.body;
+
+        expect(todo).toHaveProperty("_id", originalTodo._id);
+        expect(todo).toHaveProperty("textBody", originalTodo.textBody);
+        expect(todo).toHaveProperty("isComplete", originalTodo.isComplete);
+        expect(todo).toHaveProperty("createdAt", originalTodo.createdAt);
+        expect(todo).toHaveProperty("updatedAt", originalTodo.updatedAt);
+        expect(todos).toHaveLength(0);
+      });
+    });
+    describe("failure", () => {
+      it("should 404 when no todo is found", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+        await request(app).delete(`/todos/${originalTodo._id}`);
+
+        const res = await request(app).delete(`/todos/${originalTodo._id}`);
+        expectStatusCode(res, 404);
+      });
+
+      it("should 404 requests with no id", async () => {
+        const postRes = await request(app).post("/todos").send(testData);
+        const originalTodo = postRes.body.todo;
+
+        const res = await request(app).delete("/todos");
+        expect(Object.is(res, null)).toBe(false);
+        expect(res).toHaveProperty("statusCode", 404);
+      });
+
+      it("should 400 requests with an invalid id format", async () => {
+        const res = await request(app).delete("/todos/1");
+        expectStatusCode(res, 400);
+      });
+    });
   });
 });
 

--- a/src/tests/todoService.test.ts
+++ b/src/tests/todoService.test.ts
@@ -2,7 +2,7 @@ import * as TodoService from "../services/todoService";
 import { ITodo } from "../types";
 import * as db from "./testDb";
 
-describe("Todo service", () => {
+describe("todoService", () => {
   beforeAll(async () => {
     await db.connect();
   });
@@ -26,190 +26,228 @@ describe("Todo service", () => {
   const longTextBody =
     "11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111 11111111111111111111111111111111111111111111111111";
 
-  it("should create a todo", async () => {
-    const todo = await TodoService.create(testData.textBody);
-    expect(Object.is(todo, null)).toBe(false);
-    expect(todo).toHaveProperty("_id");
-    expect(todo).toHaveProperty("textBody", testData.textBody);
-    expect(todo).toHaveProperty("isComplete", false);
-    expect(todo).toHaveProperty("createdAt");
-    expect(todo).toHaveProperty("updatedAt");
+  describe(".create(textBody: string)", () => {
+    describe("success", () => {
+      it("should create a todo", async () => {
+        const todo = await TodoService.create(testData.textBody);
+        expect(Object.is(todo, null)).toBe(false);
+        expect(todo).toHaveProperty("_id");
+        expect(todo).toHaveProperty("textBody", testData.textBody);
+        expect(todo).toHaveProperty("isComplete", false);
+        expect(todo).toHaveProperty("createdAt");
+        expect(todo).toHaveProperty("updatedAt");
 
-    const todos = await TodoService.readAll();
-    expect(todos).toHaveLength(1);
+        const todos = await TodoService.readAll();
+        expect(todos).toHaveLength(1);
+      });
+    });
+    describe("failure", () => {
+      it("should throw an error when creating a todo with an empty string", async () => {
+        try {
+          await TodoService.create("");
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+
+      it("should throw an error when creating a todo with a string over 255 characters long", async () => {
+        try {
+          await TodoService.create(longTextBody);
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+    });
   });
 
-  it("should fetch a todo", async () => {
-    const expected = await TodoService.create(testData.textBody);
-    const actual = await TodoService.readById(expected._id);
-    expectToHaveSameProperties(actual, expected);
+  describe(".readAll()", () => {
+    describe("success", () => {
+      it("should fetch all todos", async () => {
+        const TODOS_COUNT = 3;
+        const testData = [
+          { textBody: "testA" },
+          { textBody: "testB" },
+          { textBody: "testC" },
+        ];
+
+        let expected = [];
+        for (let i = 0; i < TODOS_COUNT; i++) {
+          expected[i] = await TodoService.create(testData[i].textBody);
+        }
+
+        const actual = await TodoService.readAll();
+        expect(actual).toHaveLength(TODOS_COUNT);
+        for (let i = 0; i < TODOS_COUNT; i++) {
+          expect(actual[i].toJSON).toEqual(expected[i].toJSON);
+        }
+      });
+
+      it("should fetch all todos as an empty array if no todos are found", async () => {
+        const allTodos = await TodoService.readAll();
+        expect(Object.is(allTodos, null)).toBe(false);
+        expect(allTodos).toHaveLength(0);
+        expect(allTodos).toStrictEqual([]);
+      });
+    });
+    describe("failure", () => {});
   });
 
-  it("should fetch all todos", async () => {
-    const TODOS_COUNT = 3;
-    const testData = [
-      { textBody: "testA" },
-      { textBody: "testB" },
-      { textBody: "testC" },
-    ];
+  describe(".readById(id: string)", () => {
+    describe("success", () => {
+      it("should fetch a todo", async () => {
+        const expected = await TodoService.create(testData.textBody);
+        const actual = await TodoService.readById(expected._id);
+        expectToHaveSameProperties(actual, expected);
+      });
+    });
+    describe("failure", () => {
+      it("should return null when fetching a todo and no todo is found", async () => {
+        const expected = await TodoService.create(testData.textBody);
+        await TodoService.deleteById(expected._id);
+        const actual = await TodoService.readById(expected._id);
+        expect(Object.is(actual, null)).toBe(true);
+      });
 
-    let expected = [];
-    for (let i = 0; i < TODOS_COUNT; i++) {
-      expected[i] = await TodoService.create(testData[i].textBody);
-    }
-
-    const actual = await TodoService.readAll();
-    expect(actual).toHaveLength(TODOS_COUNT);
-    for (let i = 0; i < TODOS_COUNT; i++) {
-      expect(actual[i].toJSON).toEqual(expected[i].toJSON);
-    }
+      it("should throw an error when fetching a todo with an invalid id format", async () => {
+        try {
+          await TodoService.readById("1");
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+    });
   });
 
-  it("should fetch all todos as an empty array if no todos are found", async () => {
-    const allTodos = await TodoService.readAll();
-    expect(Object.is(allTodos, null)).toBe(false);
-    expect(allTodos).toHaveLength(0);
-    expect(allTodos).toStrictEqual([]);
+  describe(".updateCompleteById(id: string)", () => {
+    describe("success", () => {
+      it("should update the completion status of a todo", async () => {
+        const originalTodo = await TodoService.create(testData.textBody);
+        const updatedTodo = await TodoService.updateCompleteById(
+          originalTodo._id
+        );
+        expect(Object.is(updatedTodo, null)).toBe(false);
+        expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
+        expect(updatedTodo).toHaveProperty("textBody", originalTodo.textBody);
+        expect(updatedTodo).toHaveProperty(
+          "isComplete",
+          !originalTodo.isComplete
+        );
+        expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
+        expect(updatedTodo).toHaveProperty("updatedAt");
+        expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
+
+        const todos = await TodoService.readAll();
+        expect(todos).toHaveLength(1);
+      });
+    });
+    describe("failure", () => {
+      it("should return null when updating the completion status of a todo and no todo is found", async () => {
+        const expected = await TodoService.create(testData.textBody);
+        await TodoService.deleteById(expected._id);
+        const actual = await TodoService.updateCompleteById(expected._id);
+        expect(Object.is(actual, null)).toBe(true);
+      });
+
+      it("should throw an error when updating the completion status of a todo with an invalid id format", async () => {
+        try {
+          await TodoService.updateCompleteById("1");
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+    });
   });
 
-  it("should update the text of a todo", async () => {
-    const originalTodo = await TodoService.create(testData.textBody);
-    const updatedTodo = await TodoService.updateTextById(
-      originalTodo._id,
-      updateData.textBody
-    );
-    expect(Object.is(updatedTodo, null)).toBe(false);
-    expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
-    expect(updatedTodo).toHaveProperty("textBody", updateData.textBody);
-    expect(updatedTodo).toHaveProperty("isComplete", originalTodo.isComplete);
-    expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
-    expect(updatedTodo).toHaveProperty("updatedAt");
-    expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
+  describe(".updateTextById(id: string, textBody: string)", () => {
+    describe("success", () => {
+      it("should update the text of a todo", async () => {
+        const originalTodo = await TodoService.create(testData.textBody);
+        const updatedTodo = await TodoService.updateTextById(
+          originalTodo._id,
+          updateData.textBody
+        );
+        expect(Object.is(updatedTodo, null)).toBe(false);
+        expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
+        expect(updatedTodo).toHaveProperty("textBody", updateData.textBody);
+        expect(updatedTodo).toHaveProperty(
+          "isComplete",
+          originalTodo.isComplete
+        );
+        expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
+        expect(updatedTodo).toHaveProperty("updatedAt");
+        expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
 
-    const todos = await TodoService.readAll();
-    expect(todos).toHaveLength(1);
+        const todos = await TodoService.readAll();
+        expect(todos).toHaveLength(1);
+      });
+    });
+    describe("failure", () => {
+      it("should return null when updating the text of a todo and no todo is found", async () => {
+        const expected = await TodoService.create(testData.textBody);
+        await TodoService.deleteById(expected._id);
+        const actual = await TodoService.updateTextById(
+          expected._id,
+          updateData.textBody
+        );
+        expect(Object.is(actual, null)).toBe(true);
+      });
+
+      it("should throw an error when updating the text of a todo with an invalid id format", async () => {
+        try {
+          await TodoService.updateTextById("1", updateData.textBody);
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+
+      it("should throw an error when updating a todo with an empty string", async () => {
+        try {
+          const originalTodo = await TodoService.create(testData.textBody);
+          await TodoService.updateTextById(originalTodo._id, "");
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+
+      it("should throw an error when updating a todo with a string over 255 characters long", async () => {
+        try {
+          const originalTodo = await TodoService.create(testData.textBody);
+          await TodoService.updateTextById(originalTodo._id, longTextBody);
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+    });
   });
 
-  it("should update the completion status of a todo", async () => {
-    const originalTodo = await TodoService.create(testData.textBody);
-    const updatedTodo = await TodoService.updateCompleteById(originalTodo._id);
-    expect(Object.is(updatedTodo, null)).toBe(false);
-    expect(updatedTodo).toHaveProperty("_id", originalTodo._id);
-    expect(updatedTodo).toHaveProperty("textBody", originalTodo.textBody);
-    expect(updatedTodo).toHaveProperty("isComplete", !originalTodo.isComplete);
-    expect(updatedTodo).toHaveProperty("createdAt", originalTodo.createdAt);
-    expect(updatedTodo).toHaveProperty("updatedAt");
-    expect(updatedTodo.updatedAt).not.toBe(originalTodo.updatedAt);
+  describe(".deleteById(id: string)", () => {
+    describe("success", () => {
+      it("should delete a todo", async () => {
+        const originalTodo = await TodoService.create(testData.textBody);
+        const deletedTodo = await TodoService.deleteById(originalTodo._id);
+        expect(Object.is(deletedTodo, null)).toBe(false);
+        expectToHaveSameProperties(deletedTodo, originalTodo);
 
-    const todos = await TodoService.readAll();
-    expect(todos).toHaveLength(1);
-  });
+        const allTodos = await TodoService.readAll();
+        expect(allTodos).toHaveLength(0);
+      });
+    });
+    describe("failure", () => {
+      it("should return null when deleting a todo and no todo is found", async () => {
+        const expected = await TodoService.create(testData.textBody);
+        await TodoService.deleteById(expected._id);
+        const actual = await TodoService.deleteById(expected._id);
+        expect(Object.is(actual, null)).toBe(true);
+      });
 
-  it("should delete a todo", async () => {
-    const originalTodo = await TodoService.create(testData.textBody);
-    const deletedTodo = await TodoService.deleteById(originalTodo._id);
-    expect(Object.is(deletedTodo, null)).toBe(false);
-    expectToHaveSameProperties(deletedTodo, originalTodo);
-
-    const allTodos = await TodoService.readAll();
-    expect(allTodos).toHaveLength(0);
-  });
-
-  it("should return null when fetching a todo and no todo is found", async () => {
-    const expected = await TodoService.create(testData.textBody);
-    await TodoService.deleteById(expected._id);
-    const actual = await TodoService.readById(expected._id);
-    expect(Object.is(actual, null)).toBe(true);
-  });
-
-  it("should return null when updating the text of a todo and no todo is found", async () => {
-    const expected = await TodoService.create(testData.textBody);
-    await TodoService.deleteById(expected._id);
-    const actual = await TodoService.updateTextById(
-      expected._id,
-      updateData.textBody
-    );
-    expect(Object.is(actual, null)).toBe(true);
-  });
-
-  it("should return null when updating the completion status of a todo and no todo is found", async () => {
-    const expected = await TodoService.create(testData.textBody);
-    await TodoService.deleteById(expected._id);
-    const actual = await TodoService.updateCompleteById(expected._id);
-    expect(Object.is(actual, null)).toBe(true);
-  });
-
-  it("should return null when deleting a todo and no todo is found", async () => {
-    const expected = await TodoService.create(testData.textBody);
-    await TodoService.deleteById(expected._id);
-    const actual = await TodoService.deleteById(expected._id);
-    expect(Object.is(actual, null)).toBe(true);
-  });
-
-  it("should throw an error when creating a todo with an empty string", async () => {
-    try {
-      await TodoService.create("");
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when creating a todo with a string over 255 characters long", async () => {
-    try {
-      await TodoService.create(longTextBody);
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when fetching a todo with an invalid id format", async () => {
-    try {
-      await TodoService.readById("1");
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when updating the text of a todo with an invalid id format", async () => {
-    try {
-      await TodoService.updateTextById("1", updateData.textBody);
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when updating the completion status of a todo with an invalid id format", async () => {
-    try {
-      await TodoService.updateCompleteById("1");
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when updating a todo with an empty string", async () => {
-    try {
-      const originalTodo = await TodoService.create(testData.textBody);
-      await TodoService.updateTextById(originalTodo._id, "");
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when updating a todo with a string over 255 characters long", async () => {
-    try {
-      const originalTodo = await TodoService.create(testData.textBody);
-      await TodoService.updateTextById(originalTodo._id, longTextBody);
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
-  });
-
-  it("should throw an error when deleting a todo with an invalid id format", async () => {
-    try {
-      await TodoService.deleteById("1");
-    } catch (err) {
-      expect(err).toHaveProperty("message");
-    }
+      it("should throw an error when deleting a todo with an invalid id format", async () => {
+        try {
+          await TodoService.deleteById("1");
+        } catch (err) {
+          expect(err).toHaveProperty("message");
+        }
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Reorganized tests by HTTP verb or function and success or failure. Closes #12 